### PR TITLE
Add support for all available compressed ARM formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install libarchive-dev
+
       - name: Checkout sources
         uses: actions/checkout@v1
 
@@ -26,6 +29,9 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install libarchive-dev
+
       - name: Checkout sources
         uses: actions/checkout@v1
 
@@ -45,6 +51,9 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     steps:
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install libarchive-dev
+
       - name: Checkout sources
         uses: actions/checkout@v1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ travis-ci = { repository = "OSSystems/find-binary-version-rs" }
 
 [dependencies]
 byteorder = "1"
+compress-tools = "0.4"
 regex = "1"
-flate2 = "1"
 
 [dev-dependencies]
 exitfailure = "0.5"


### PR DESCRIPTION
This commit moves the uncompression handling from flate2 to compress-tools and add support for other compressed formats of ARM Linux Kernel.